### PR TITLE
Bugfix/subbreed upload

### DIFF
--- a/Dog API Test.postman_collection.json
+++ b/Dog API Test.postman_collection.json
@@ -45,6 +45,24 @@
 		},
 		{
 			"name": "POST Breed, No Array.",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "3973de25-fab1-4277-b263-4d09e33e64c9",
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([201,202]);",
+							"});",
+							"",
+							"pm.test(\"Response time is less than 200ms\", function () {",
+							"    pm.expect(pm.response.responseTime).to.be.below(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -55,7 +73,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"breedName\": \"New Dog\"\n}"
+					"raw": "{\n    \"breedName\": \"POST; No Array\"\n}"
 				},
 				"url": {
 					"raw": "https://localhost:44371/api/dogbreed/",
@@ -75,6 +93,24 @@
 		},
 		{
 			"name": "POST Breed, Empty Array",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "210d9388-fca8-413e-8c3a-9b0d8dd92ff2",
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([201,202]);",
+							"});",
+							"",
+							"pm.test(\"Response time is less than 200ms\", function () {",
+							"    pm.expect(pm.response.responseTime).to.be.below(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -85,7 +121,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"breedName\": \"New Dog\",\n\t\"subBreeds\": []\n}"
+					"raw": "{\n    \"breedName\": \"POST; Empty Array\",\n\t\"subBreeds\": []\n}"
 				},
 				"url": {
 					"raw": "https://localhost:44371/api/dogbreed/",
@@ -105,6 +141,20 @@
 		},
 		{
 			"name": "POST Breed, Array, Single Entry",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "268319c8-0d7e-445f-bf49-1e23f04f24fb",
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([201,202]);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -115,7 +165,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"breedName\": \"New Dog\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"staffordshire\"\n        }\n    ]\n}"
+					"raw": "{\n    \"breedName\": \"POST; Single Sub-breed\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"staffordshire\"\n        }\n    ]\n}"
 				},
 				"url": {
 					"raw": "https://localhost:44371/api/dogbreed/",
@@ -135,6 +185,20 @@
 		},
 		{
 			"name": "POST Breed, Array, Duplicate Entries",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "1cd56477-8aca-4698-b76c-d0fb4c43efec",
+						"exec": [
+							"pm.test(\"Status code is 422\", function () {",
+							"    pm.response.to.have.status(422);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -145,7 +209,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"breedName\": \"New Dog\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        },\n        {\n            \"subBreedName\": \"Sub Breed 2\"\n        }\n    ]\n}"
+					"raw": "{\n    \"breedName\": \"POST;Dupe Sub-breeds\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        },\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        }\n    ]\n}"
 				},
 				"url": {
 					"raw": "https://localhost:44371/api/dogbreed/",
@@ -165,6 +229,22 @@
 		},
 		{
 			"name": "POST Breed, Array, Multiple Entries",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "0512b14a-0891-41fe-94aa-4fcdefd3e81e",
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([201,202]);",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -175,7 +255,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"breedName\": \"Newafa Dog\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        },\n        {\n            \"subBreedName\": \"Sub Breed 2\"\n        }\n    ]\n}"
+					"raw": "{\n    \"breedName\": \"POST;Multiple Valid Sub-breeds\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        },\n        {\n            \"subBreedName\": \"Sub Breed 2\"\n        }\n    ]\n}"
 				},
 				"url": {
 					"raw": "https://localhost:44371/api/dogbreed/",
@@ -195,6 +275,20 @@
 		},
 		{
 			"name": "POST Breed, No name value",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "ebc1c754-64be-4b0f-961d-421a198757b7",
+						"exec": [
+							"pm.test(\"Status code is 422\", function () {",
+							"    pm.response.to.have.status(422);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -225,6 +319,20 @@
 		},
 		{
 			"name": "POST Breed, Null Value",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "cdffab2c-973a-4214-8afc-9a72825d49de",
+						"exec": [
+							"pm.test(\"Status code is 422\", function () {",
+							"    pm.response.to.have.status(422);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [

--- a/Dog API Test.postman_collection.json
+++ b/Dog API Test.postman_collection.json
@@ -44,7 +44,7 @@
 			"response": []
 		},
 		{
-			"name": "POST Breed",
+			"name": "POST Breed, No Array.",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -55,10 +55,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"dogBreedItemId\": 3,\n    \"breedName\": \"Hound3\",\n    \"subBreeds\": [\n        {\n            \"parentBreedId\": 3,\n            \"dogSubBreedId\": 7,\n            \"subBreedName\": \"Hound3.1\"\n        },\n        {\n            \"parentBreedId\": 3,\n            \"dogSubBreedId\": 8,\n            \"subBreedName\": \"Hound3.2\"\n        }\n    ]\n}"
+					"raw": "{\n    \"breedName\": \"New Dog\"\n}"
 				},
 				"url": {
-					"raw": "https://localhost:44371/api/dogbreed",
+					"raw": "https://localhost:44371/api/dogbreed/",
 					"protocol": "https",
 					"host": [
 						"localhost"
@@ -66,7 +66,188 @@
 					"port": "44371",
 					"path": [
 						"api",
-						"dogbreed"
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, Empty Array",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": \"New Dog\",\n\t\"subBreeds\": []\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, Array, Single Entry",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": \"New Dog\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"staffordshire\"\n        }\n    ]\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, Array, Duplicate Entries",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": \"New Dog\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        },\n        {\n            \"subBreedName\": \"Sub Breed 2\"\n        }\n    ]\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, Array, Multiple Entries",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": \"Newafa Dog\",\n    \"subBreeds\": [\n        {\n            \"subBreedName\": \"Sub Breed 1\"\n        },\n        {\n            \"subBreedName\": \"Sub Breed 2\"\n        }\n    ]\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, No name value",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": \"\"\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, Null Value",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": null\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
 					]
 				}
 			},
@@ -76,13 +257,20 @@
 			"name": "PUT Breed",
 			"request": {
 				"method": "PUT",
-				"header": [],
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
 				"body": {
 					"mode": "raw",
-					"raw": ""
+					"raw": "{\n    \"dogBreedItemId\": null,\n    \"breedName\": \"bullterrier\",\n    \"subBreeds\": [\n        {\n            \"parentBreedId\": 15,\n            \"dogSubBreedId\": 3,\n            \"subBreedName\": \"banana\"\n        }\n    ]\n}"
 				},
 				"url": {
-					"raw": "https://localhost:44371/api/dogbreed",
+					"raw": "https://localhost:44371/api/dogbreed/15",
 					"protocol": "https",
 					"host": [
 						"localhost"
@@ -90,7 +278,8 @@
 					"port": "44371",
 					"path": [
 						"api",
-						"dogbreed"
+						"dogbreed",
+						"15"
 					]
 				}
 			},

--- a/Dog API Test.postman_collection.json
+++ b/Dog API Test.postman_collection.json
@@ -318,7 +318,7 @@
 			"response": []
 		},
 		{
-			"name": "POST Breed, Null Value",
+			"name": "POST Breed, Null Breed Name Value",
 			"event": [
 				{
 					"listen": "test",
@@ -344,6 +344,50 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n    \"breedName\": null\n}"
+				},
+				"url": {
+					"raw": "https://localhost:44371/api/dogbreed/",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "44371",
+					"path": [
+						"api",
+						"dogbreed",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST Breed, Null Sub-breed Value",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "cdffab2c-973a-4214-8afc-9a72825d49de",
+						"exec": [
+							"pm.test(\"Status code is 422\", function () {",
+							"    pm.response.to.have.status(422);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"breedName\": \"POST; NullSubBreed\",\n\t\"subBreeds\": \n\t[\n\t    {\n\t    \t\"subBreedName\":null\n\t    }\n\t]\n}"
 				},
 				"url": {
 					"raw": "https://localhost:44371/api/dogbreed/",

--- a/RestClient/Controllers/DogBreedController.cs
+++ b/RestClient/Controllers/DogBreedController.cs
@@ -135,13 +135,30 @@
                 if (dogBreed.BreedName == "" || dogBreed.BreedName == null)
                 {
                     return UnprocessableEntity("\"Error\" : \"Please provide a 'breedName' property, and non-empty string value.\"");
-                }            
+                }
+
+                bool emptySubBreedList = false;
 
                 //Validate subbreed details
                 ///If we have nothing in the payload for subbreeds, create an empty list for it.
                 if (dogBreed.SubBreeds == null)
                 {
                     dogBreed.SubBreeds = new List<DogSubBreed>();
+                    emptySubBreedList = true;
+                }
+
+                if (!emptySubBreedList)
+                {
+                    if (dogBreed.SubBreeds.Count != 0)
+                    {
+                        foreach(var x in dogBreed.SubBreeds )
+                        {
+                            if (x.SubBreedName == "" || x.SubBreedName == null)
+                            {
+                                return UnprocessableEntity("\"Error\" : \"Please provide a 'subBreedName' property on each sub-breed, and non-empty string value.\"");
+                            }
+                        }
+                    }
                 }
 
                 var hashSet1 = new HashSet<string>();

--- a/RestClient/Controllers/DogBreedController.cs
+++ b/RestClient/Controllers/DogBreedController.cs
@@ -129,7 +129,7 @@
                 //Validate breed details
                 if (dataContext.DogBreedItemList.Any( x => x.BreedName == dogBreed.BreedName))
                 {                    
-                    return UnprocessableEntity($"\"Error\" :: \"Breed Name {dogBreed.BreedName} already exists.\"");
+                    return UnprocessableEntity($"\"Error\" : \"Breed Name {dogBreed.BreedName} already exists.\"");
                 }
 
                 if (dogBreed.BreedName == "" || dogBreed.BreedName == null)
@@ -152,7 +152,6 @@
 
                 //Save dog breed to context when we've verified it has a unique name
                 dataContext.DogBreedItemList.Add(dogBreed);
-
                 await dataContext.SaveChangesAsync();
 
                 //If we've got sub-breeds
@@ -165,15 +164,14 @@
                 }
 
                 //Return object we successfully built
-                return Ok(dataContext.DogBreedItemList.Find(dogBreed.DogBreedItemId));
+                return Created($"api/dogbreed/{dogBreed.DogBreedItemId}",dataContext.DogBreedItemList.Find(dogBreed.DogBreedItemId));
             }
             catch
             {
                 dataContext.DogBreedItemList.Remove(dogBreed);
                 await dataContext.SaveChangesAsync();
                 return UnprocessableEntity("Could not process. Check your formatting for missing parenthesis and list seperators.");
-            }
-                
+            }                
         }
 
         #endregion


### PR DESCRIPTION
Updated sub-breed POST to now do error handling on the json object it receives. 

Corrects what it can, where it can; it will fail and give an error code with a hint to the user if the data isn't handled.

Added a collection of Postman tests which give automated results based on the expected server response codes.

Tests:
Happy Path:
- Array, Valid Single Entry
- Array, Multiple Valid Entries

Handled Sad Path:
- No Subbreed Array
- Empty Subbreed Array

Unrecoverable Sad Path, inform user:
- Array, InvalidDuplicate Entries
- Breed Name; Null
- Breed Name; Empty
- Subbreed Name: Null/Empty



